### PR TITLE
Drush 9 version fails with older versions of default content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
   "type": "drupal-drush",
   "license": "GPL-2.0+",
   "require": {
-    "drupal-code-builder/drupal-code-builder": "^3.2.0"
+    "drupal-code-builder/drupal-code-builder": "^3.2.0",
+    "drupal/default_content": "^1.0-alpha7"
   },
   "require-dev": {
     "symfony/var-dumper": "^3.2"


### PR DESCRIPTION
In my installation I had an older version of the Default Content module installed, and when I try one of the code builder commands I get the following error:

> Error: Class '\Drupal\default_content\Commands\DefaultContentCommands' not found in Drupal\Component\DependencyInjection\Container->createService() (line 262 of web/core/lib/Drupal/Component/DependencyInjection/Container.php)

Drush 9 support was added in version 8.x-1.0-alpha7 of that module (ref [Issue #2912723: Add Drush 9 support](https://www.drupal.org/node/2912723)).

This PR adds that version as a minimum requirement to`composer.json`. This is not entirely correct since we only depend indirectly on Default Content (through the main drupal-code-builder dependency) but at least this will help people use the commands for now.