### PR TITLE
Update README to use Drush 9 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Builder.
 
 The following commands are available:
 
-- `drush cb-list`: Lists all the hooks, services, and plugins that Drupal Code
+- `drush cb:list`: Lists all the hooks, services, and plugins that Drupal Code
   Builder has detected in your Drupal site's codebase.
-- `drush cb-update`: Updates the stored definitions of Drupal hooks, services
+- `drush cb:update`: Updates the stored definitions of Drupal hooks, services
   and plugin types.
-- `drush cb-module`: Creates a module, or adds components to one.
+- `drush cb:module`: Creates a module, or adds components to one.
 
 ## A note on history
 


### PR DESCRIPTION
The Drush 8 command names are still used in the README.